### PR TITLE
correction on row 49

### DIFF
--- a/moblizer
+++ b/moblizer
@@ -46,7 +46,7 @@ print ""
 print "Test started for "+b
 call(['apktool','d',b])
 flist=[]
-dirp=b.strip('.apk')
+dirp=b.replace(".apk", "")
 rootpath="./"+dirp
 ip = re.compile('((?:\d{1,3}\.){3}\d{1,3})')
 email=re.compile('([\w.]+)@([\w.]+)')


### PR DESCRIPTION
Replaced the str.strip with str.replace. 

Running the script with the old strip method was faulty when target apk-file had any of the characters a, p or k in its name. str.replace is the correct way to strip the ".apk" out of the name, I believe. Works for me at least...
